### PR TITLE
Wait for CSR approval in case template requires it

### DIFF
--- a/src/ACMEServer.Abstractions/LogMessages.cs
+++ b/src/ACMEServer.Abstractions/LogMessages.cs
@@ -330,7 +330,7 @@ public static partial class LogMessages
         Level = LogLevel.Debug,
         Message = "TXT record {record} could not be parsed: multiple or no accountUri parameters detected.")]
     public static partial void DnsPersist01ChallengeResponseParseFailedAccountUri(this ILogger logger, string record);
-    
+
     [LoggerMessage(
         EventId = 1204,
         Level = LogLevel.Debug,
@@ -479,6 +479,12 @@ public static partial class LogMessages
         Level = LogLevel.Information,
         Message = "Selected certificate service with CA server {CaServer} and template {TemplateName} for CSR with key type {KeyType} and key size {KeySize}.")]
     public static partial void SelectedCAConfig(this ILogger logger, string? keyType, int? keySize, string caServer, string templateName);
+
+    [LoggerMessage(
+        EventId = 2020,
+        Level = LogLevel.Information,
+        Message = "Waiting approval for certificate with ID {certificateId}. Waiting {timeout} seconds for next check.")]
+    public static partial void WaitingCertificateApproval(this ILogger logger, int certificateId, int timeout);
     #endregion
 
     #region AcmeExceptionHandlerMiddleware (3000-3019)

--- a/src/ACMEServer.CertProvider.ADCS/CertificateIssuer.cs
+++ b/src/ACMEServer.CertProvider.ADCS/CertificateIssuer.cs
@@ -72,7 +72,15 @@ public sealed class CertificateIssuer : ICertificateIssuer
             using var attributesHandle = new SysFreeStringSafeHandle(Marshal.StringToBSTR(attributes));
 
             certRequest.Submit((int)CERT_IMPORT_FLAGS.CR_IN_BASE64, csrHandle, attributesHandle, configHandle, out var submitResponseCode);
+            certRequest.GetRequestId(out var certificateId);
 
+            for (int i = 1; i <= 5 && submitResponseCode == 5; i++)
+            {
+                _logger.WaitingCertificateApproval(certificateId, i * 5);
+                await Task.Delay(i * 5000);
+
+                certRequest.RetrievePending(certificateId, configHandle, out submitResponseCode);
+            }
             if (submitResponseCode == 3)
             {
                 certRequest.GetCertificate(CR_OUT_BASE64 | CR_OUT_CHAIN, out var responseHandle);


### PR DESCRIPTION
As it stands right now, ACME-Server-ADCS doesn't wait for a CSR to be approved if the template requires it, instead, it fails if the response from AD CS wasn't an immediate success. This PR aims to fix that behavior.